### PR TITLE
Add docs for API key & fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cp .env.example .env # Fill out all the necessary fields
 ## 🔑 Getting your API key
 Head to the [API keys](https://creator.tebex.io/developers/api-keys) page within your creator panel. You'll find a private key and a public token.
 
-Inside your **.env`** file, do the following:
+Inside your **.env** file, do the following:
 1. Set the `NUXT_PUBLIC_API_PUBLIC_KEY` key to your public token.
 2. Set the `NUXT_API_PRIVATE_KEY` key to your private key.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Create a .env file
 cp .env.example .env # Fill out all the necessary fields
 ```
 
+## 🔑 Getting your API key
+Head to the [API keys](https://creator.tebex.io/developers/api-keys) page within your creator panel. You'll find a private key and a public token.
+
+Inside your **.env`** file, do the following:
+1. Set the `NUXT_PUBLIC_API_PUBLIC_KEY` key to your public token.
+2. Set the `NUXT_API_PRIVATE_KEY` key to your private key.
+
 ## ⚙️ Configuring
 Update config in `app.config.ts` with your custom configuration options for your webstore.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module "nuxt/schema" {
         // URL of main site
         mainSiteUrl: string;
         // Discord invite URL
-        discortUrl: string;
+        discordUrl: string;
         // Game server IP/Hostname for the store (used for copy IP button)
         serverIp: string;
         // Prefix for the <title> tag


### PR DESCRIPTION
As the PR title implies, I’ve just added some further information on getting the relevant keys.

Also fixed a typo with the discord type.